### PR TITLE
PHP Deprecated: Hook contextual_help is deprecated since version 3.3.…

### DIFF
--- a/lib/class-sendgrid-settings.php
+++ b/lib/class-sendgrid-settings.php
@@ -48,8 +48,6 @@ class Sendgrid_Settings {
       // Add SendGrid settings page in the network admin menu
       add_action( 'network_admin_menu', array( __CLASS__, 'add_network_settings_menu' ) );
     }
-    // Add SendGrid Help contextual menu in the settings page
-    add_filter( 'contextual_help', array( __CLASS__, 'show_contextual_help' ), 10, 3 );
     // Add SendGrid javascripts in header
     add_action( 'admin_enqueue_scripts', array( __CLASS__, 'add_headers' ) );
   }
@@ -86,25 +84,6 @@ class Sendgrid_Settings {
     array_unshift( $links, $settings_link );
 
     return $links;
-  }
-
-  /**
-   * Add SendGrid Help contextual menu in the settings page
-   *
-   * @param   mixed   $contextual_help    contextual help
-   * @param   integer $screen_id          screen id
-   * @param   integer $screen             screen
-   *
-   * @return  string
-   */
-  public static function show_contextual_help( $contextual_help, $screen_id, $screen )
-  {
-    if ( SENDGRID_PLUGIN_STATISTICS == $screen_id or SENDGRID_PLUGIN_SETTINGS == $screen_id )
-    {
-      $contextual_help = file_get_contents( dirname( __FILE__ ) . '/../view/sendgrid_contextual_help.php' );
-    }
-
-    return $contextual_help;
   }
 
   /**


### PR DESCRIPTION
…0! Use get_current_screen()->add_help_tab(), get_current_screen()->remove_help_tab() instead. in /srv/users/serverpilot/apps/frosty-media/public/wp-includes/functions.php on line 6031